### PR TITLE
Support rendering menus in 3D

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -65,7 +65,7 @@ target_link_libraries(${PROJECT_NAME} PUBLIC
 
 set_target_properties(${PROJECT_NAME}
 PROPERTIES
-	VS_DEBUGGER_COMMAND "i:\\RBR\\RichardBurnsRally_SSE.exe"
+	VS_DEBUGGER_COMMAND "${CMAKE_INSTALL_PREFIX}\\RichardBurnsRally_SSE.exe"
 	VS_DEBUGGER_COMMAND_ARGUMENTS "$<TARGET_FILE:${PROJECT_NAME}>"
 )
 
@@ -85,7 +85,7 @@ add_custom_target(fmt
 )
 
 add_custom_target(build_and_copy
-    COMMAND copy ${CMAKE_BUILD_TYPE}\\openRBRVR.dll I:\\RBR\\Plugins
+    COMMAND copy ${CMAKE_BUILD_TYPE}\\openRBRVR.dll ${CMAKE_INSTALL_PREFIX}\\Plugins
     WORKING_DIRECTORY ${CMAKE_BINARY_DIR}
 )
 add_dependencies(build_and_copy ${PROJECT_NAME})

--- a/Config.hpp
+++ b/Config.hpp
@@ -45,6 +45,9 @@ struct Config {
     bool drawCompanionWindow;
     bool drawLoadingScreen;
     bool debug;
+    bool renderMainMenu3d;
+    bool renderPauseMenu3d;
+    bool renderPreStage3d;
 
     auto operator<=>(const Config&) const = default;
 
@@ -60,7 +63,10 @@ struct Config {
             "lockToHorizon = {}\n"
             "drawDesktopWindow = {}\n"
             "drawLoadingScreen = {}\n"
-            "debug = {}",
+            "debug = {}\n"
+            "renderMainMenu3d = {}\n"
+            "renderPauseMenu3d = {}\n"
+            "renderPreStage3d = {}",
             superSampling,
             menuSize,
             overlaySize,
@@ -70,7 +76,10 @@ struct Config {
             (int)lockToHorizon,
             drawCompanionWindow,
             drawLoadingScreen,
-            debug);
+            debug,
+            renderMainMenu3d,
+            renderPauseMenu3d,
+            renderPreStage3d);
     }
 
     bool Write(const std::filesystem::path& path) const
@@ -86,7 +95,8 @@ struct Config {
 
     static Config fromFile(const std::filesystem::path& path)
     {
-        auto cfg = Config {
+        auto cfg = Config
+        {
             .menuSize = 1.0,
             .overlaySize = 1.0,
             .overlayTranslation = glm::vec3 { 0.0f, 0.0f, 0.0f },
@@ -95,6 +105,9 @@ struct Config {
             .drawCompanionWindow = true,
             .drawLoadingScreen = true,
             .debug = false,
+            .renderMainMenu3d = false,
+            .renderPauseMenu3d = true,
+            .renderPreStage3d = false,
         };
 
         if (!std::filesystem::exists(path)) {
@@ -146,6 +159,12 @@ struct Config {
                 cfg.drawLoadingScreen = (value == "true");
             } else if (key == "debug") {
                 cfg.debug = (value == "true");
+            } else if (key == "renderMainMenu3d") {
+                cfg.renderMainMenu3d = (value == "true");
+            } else if (key == "renderPauseMenu3d") {
+                cfg.renderPauseMenu3d = (value == "true");
+            } else if (key == "renderPreStage3d") {
+                cfg.renderPreStage3d = (value == "true");
             }
         }
         return cfg;

--- a/openRBRVR.ini.sample
+++ b/openRBRVR.ini.sample
@@ -8,3 +8,6 @@ overlayTranslateZ = 0.0
 ; 1 = roll, 2 = pitch, 3 = pitch+roll
 lockToHorizon = 0
 debug = false
+renderMainMenu3d = false
+renderPauseMenu3d = true
+renderPreStage3d = false


### PR DESCRIPTION
Add configurable 3D rendering for:
1. pause menu
2. pre-stage (spinning camera)
3. main menu

By default, only enable the pause menu as that is static.
The other two may be nauseating to some people.

The configuration UI is a compromise given limited screen space, but .ini editing allows any combination of the settings.