### PR TITLE
Minor rendering fixes

### DIFF
--- a/VR.cpp
+++ b/VR.cpp
@@ -153,7 +153,7 @@ bool InitVR(IDirect3DDevice9* dev, const Config& cfg, IDirect3DVR9** vrdev, uint
     constexpr auto zFar = 10000.0f;
     constexpr auto zNearStage = 1.0f;
     constexpr auto zNearCockpit = 0.01f;
-    constexpr auto zNearMainMenu = 0.7f;
+    constexpr auto zNearMainMenu = 0.1f;
     gProjection[LeftEye] = GetProjectionMatrix(LeftEye, zNearStage, zFar);
     gProjection[RightEye] = GetProjectionMatrix(RightEye, zNearStage, zFar);
     gCockpitProjection[LeftEye] = GetProjectionMatrix(LeftEye, zNearCockpit, zFar);

--- a/VR.cpp
+++ b/VR.cpp
@@ -99,7 +99,7 @@ static bool CreateTexture(IDirect3DDevice9* dev, RenderTarget tgt, D3DFORMAT fmt
 
 static bool CreateVRTexture(IDirect3DDevice9* dev, RenderTarget eye, uint32_t w, uint32_t h)
 {
-    CreateTexture(dev, eye, D3DFMT_A8R8G8B8, w, h);
+    CreateTexture(dev, eye, D3DFMT_X8R8G8B8, w, h);
     openvrTexture[eye].handle = reinterpret_cast<void*>(&dxvkTexture[eye]);
     openvrTexture[eye].eType = vr::TextureType_Vulkan;
     openvrTexture[eye].eColorSpace = vr::ColorSpace_Auto;


### PR DESCRIPTION
Two single-character changes fixing some rendering issues. I assume the VR textures don't need the alpha channel but maybe you know better? If they do, maybe render a white background in the companion window first or something.

The main menu quad being clipped when you move your head should be straightforward. The exact value is probably a matter of taste, I find looking at anything closer than 10cm difficult.

Before:
![before](https://github.com/Detegr/openRBRVR/assets/245394/9794b073-9603-4357-86af-ddd16ab61b9d)

After:
![after](https://github.com/Detegr/openRBRVR/assets/245394/406ebc56-6e33-454a-81aa-5c99a56c957e)
