### PR TITLE
Reshade Compability (OpenVR crash fix)

### DIFF
--- a/src/OpenVR.hpp
+++ b/src/OpenVR.hpp
@@ -15,11 +15,13 @@ private:
     constexpr M4 GetProjectionMatrix(RenderTarget eye, float zNear, float zFar);
 
 public:
-    OpenVR(IDirect3DDevice9* dev, const Config& cfg, IDirect3DVR9** vrdev, uint32_t companionWindowWidth, uint32_t companionWindowHeight);
+    OpenVR();
     virtual ~OpenVR()
     {
         ShutdownVR();
     }
+
+    void Init(IDirect3DDevice9* dev, const Config& cfg, IDirect3DVR9** vrdev, uint32_t companionWindowWidth, uint32_t companionWindowHeight);
 
     void ShutdownVR() override
     {


### PR DESCRIPTION
As suspected the OpenVR initialization must be done before creating the D3D device to avoid reshade to cause a crash when SteamVR is already running and vrclient.dll loaded. The fix very similar to the early OpenXR init already done in code. 