### PR TITLE
OpenXR motion compensation support

### DIFF
--- a/src/Config.hpp
+++ b/src/Config.hpp
@@ -104,6 +104,7 @@ struct Config {
     int companion_size = 100;
     RenderTarget companion_eye = LeftEye;
     int world_scale = 1000;
+    bool motion_compensation_support = false; // OpenXR-MotionCompensation support https://github.com/BuzzteeBear/OpenXR-MotionCompensation
 
     Config& operator=(const Config& rhs)
     {
@@ -131,6 +132,7 @@ struct Config {
         companion_mode = rhs.companion_mode;
         debug_mode = rhs.debug_mode;
         world_scale = rhs.world_scale;
+        motion_compensation_support = rhs.motion_compensation_support;
         return *this;
     }
 
@@ -156,7 +158,8 @@ struct Config {
             && companion_offset == rhs.companion_offset
             && companion_size == rhs.companion_size
             && companion_eye == rhs.companion_eye
-            && world_scale == rhs.world_scale;
+            && world_scale == rhs.world_scale
+            && motion_compensation_support == rhs.motion_compensation_support;
     }
 
     bool write(const std::filesystem::path& path) const
@@ -189,6 +192,7 @@ struct Config {
             { "desktopWindowOffsetY", companion_offset.y },
             { "desktopWindowSize", companion_size },
             { "desktopEye", static_cast<int>(companion_eye) },
+            { "motion_compensation_support", motion_compensation_support },
         };
 
         toml::table gfxTbl;
@@ -262,6 +266,7 @@ struct Config {
         cfg.companion_offset = { parsed["desktopWindowOffsetX"].value_or(0), parsed["desktopWindowOffsetY"].value_or(0) };
         cfg.companion_size = parsed["desktopWindowSize"].value_or(100);
         cfg.companion_eye = static_cast<RenderTarget>(std::clamp(parsed["desktopEye"].value_or(0), 0, 1));
+        cfg.motion_compensation_support = parsed["motion_compensation_support"].value_or(false);
 
         const std::string& runtime = parsed["runtime"].value_or("steamvr");
         if (runtime == "openxr") {

--- a/src/Config.hpp
+++ b/src/Config.hpp
@@ -104,7 +104,7 @@ struct Config {
     int companion_size = 100;
     RenderTarget companion_eye = LeftEye;
     int world_scale = 1000;
-    bool motion_compensation_support = false; // OpenXR-MotionCompensation support https://github.com/BuzzteeBear/OpenXR-MotionCompensation
+    bool openxr_motion_compensation = false; // OpenXR-MotionCompensation support https://github.com/BuzzteeBear/OpenXR-MotionCompensation
 
     Config& operator=(const Config& rhs)
     {
@@ -132,7 +132,7 @@ struct Config {
         companion_mode = rhs.companion_mode;
         debug_mode = rhs.debug_mode;
         world_scale = rhs.world_scale;
-        motion_compensation_support = rhs.motion_compensation_support;
+        openxr_motion_compensation = rhs.openxr_motion_compensation;
         return *this;
     }
 
@@ -159,7 +159,7 @@ struct Config {
             && companion_size == rhs.companion_size
             && companion_eye == rhs.companion_eye
             && world_scale == rhs.world_scale
-            && motion_compensation_support == rhs.motion_compensation_support;
+            && openxr_motion_compensation == rhs.openxr_motion_compensation;
     }
 
     bool write(const std::filesystem::path& path) const
@@ -192,7 +192,7 @@ struct Config {
             { "desktopWindowOffsetY", companion_offset.y },
             { "desktopWindowSize", companion_size },
             { "desktopEye", static_cast<int>(companion_eye) },
-            { "motion_compensation_support", motion_compensation_support },
+            { "openXRMotionCompensation", openxr_motion_compensation },
         };
 
         toml::table gfxTbl;
@@ -266,7 +266,7 @@ struct Config {
         cfg.companion_offset = { parsed["desktopWindowOffsetX"].value_or(0), parsed["desktopWindowOffsetY"].value_or(0) };
         cfg.companion_size = parsed["desktopWindowSize"].value_or(100);
         cfg.companion_eye = static_cast<RenderTarget>(std::clamp(parsed["desktopEye"].value_or(0), 0, 1));
-        cfg.motion_compensation_support = parsed["motion_compensation_support"].value_or(false);
+        cfg.openxr_motion_compensation = parsed["openXRMotionCompensation"].value_or(false);
 
         const std::string& runtime = parsed["runtime"].value_or("steamvr");
         if (runtime == "openxr") {

--- a/src/Menu.cpp
+++ b/src/Menu.cpp
@@ -368,10 +368,10 @@ static class Menu openxr_menu = { "openRBRVR OpenXR settings", {
   },
   { .text = [] { return std::format("Support for OpenXR Motion Compensation: {}", g::cfg.openxr_motion_compensation ? "ON" : "OFF"); },
     .long_text = {
-        "When using a motion rig in combination with a VR headset (hmd) he movement of the rig ", 
-        "causes the in-game camera to change along with your position in the real world.", 
-        "Motion compensation reduces or ideally removes that effect by locking the in-game world", 
-        "to the pose of the motion rig.", 
+        "When using a motion rig in combination with a VR headset (hmd) he movement of the", 
+        "rig causes the in-game camera to change along with your position in the real world.", 
+        "Motion compensation reduces or ideally removes that effect by locking the", 
+        "in-game world to the pose of the motion rig.", 
         "OXRMC API-layer is required for it to work."
     },
     .left_action = [] { Toggle(g::cfg.openxr_motion_compensation); },

--- a/src/Menu.cpp
+++ b/src/Menu.cpp
@@ -366,6 +366,17 @@ static class Menu openxr_menu = { "openRBRVR OpenXR settings", {
     .left_action = [] { g::cfg.world_scale = std::max(g::cfg.world_scale - world_scale_step, 500); },
     .right_action = [] { g::cfg.world_scale = std::min(g::cfg.world_scale + world_scale_step, 1500); },
   },
+  { .text = [] { return std::format("Support for OpenXR Motion Compensation: {}", g::cfg.openxr_motion_compensation ? "ON" : "OFF"); },
+    .long_text = {
+        "When using a motion rig in combination with a VR headset (hmd) he movement of the rig ", 
+        "causes the in-game camera to change along with your position in the real world.", 
+        "Motion compensation reduces or ideally removes that effect by locking the in-game world", 
+        "to the pose of the motion rig.", 
+        "OXRMC API-layer is required for it to work."
+    },
+    .left_action = [] { Toggle(g::cfg.openxr_motion_compensation); },
+    .right_action = [] { Toggle(g::cfg.openxr_motion_compensation); },
+  },
   { .text = id("Back to previous menu"),
     .menu_color = IRBRGame::EMenuColors::MENU_TEXT,
     .select_action = [] { select_menu(0); },

--- a/src/OpenXR.cpp
+++ b/src/OpenXR.cpp
@@ -298,6 +298,93 @@ void OpenXR::init(IDirect3DDevice9* dev, IDirect3DVR9** vrdev, uint32_t companio
 
     view_pose = { { 0, 0, 0, 1 }, { 0, 0, 0 } };
 
+
+    //Start pose registration.
+    XrActionSetCreateInfo actionSetInfo { XR_TYPE_ACTION_SET_CREATE_INFO };
+    strcpy_s(actionSetInfo.actionSetName, "gameplay");
+    strcpy_s(actionSetInfo.localizedActionSetName, "Gameplay");
+    actionSetInfo.priority = 0;
+    if (auto res = xrCreateActionSet(instance, &actionSetInfo, &inputState.actionSet); res != XR_SUCCESS) {
+        dbg(std::format("Failed xrCreateActionSet: {}", XrResultToString(instance, res)));
+        return;
+    }
+
+    if (auto res = xrStringToPath(instance, "/user/hand/left", &inputState.handSubactionPath[Side::LEFT]); res != XR_SUCCESS) {
+        dbg(std::format("Failed to get handsSubActionPath: {}", XrResultToString(instance, res)));
+        return;
+    }
+    if (auto res = xrStringToPath(instance, "/user/hand/right", &inputState.handSubactionPath[Side::RIGHT]); res != XR_SUCCESS) {
+        dbg(std::format("Failed to get handsSubActionPath: {}", XrResultToString(instance, res)));
+        return;
+    }
+
+    // Create an input action getting the left and right hand poses.
+    XrActionCreateInfo actionInfo { XR_TYPE_ACTION_CREATE_INFO };
+    actionInfo.actionType = XR_ACTION_TYPE_POSE_INPUT;
+    strcpy_s(actionInfo.actionName, "hand_pose");
+    strcpy_s(actionInfo.localizedActionName, "Hand Pose");
+    actionInfo.countSubactionPaths = uint32_t(inputState.handSubactionPath.size());
+    actionInfo.subactionPaths = inputState.handSubactionPath.data();
+    if (auto res = xrCreateAction(inputState.actionSet, &actionInfo, &inputState.poseAction); res != XR_SUCCESS) {
+        dbg(std::format("Failed pose xrCreateAction: {}", XrResultToString(instance, res)));
+        return;
+    }
+
+    std::array<XrPath, Side::COUNT> posePath;
+
+    if (auto res = xrStringToPath(instance, "/user/hand/left/input/grip/pose", &posePath[Side::LEFT]); res != XR_SUCCESS) {
+        dbg(std::format("xrStringToPath: {}", XrResultToString(instance, res)));
+        return;
+    }
+    if (auto res = xrStringToPath(instance, "/user/hand/right/input/grip/pose", &posePath[Side::RIGHT]); res != XR_SUCCESS) {
+        dbg(std::format("xrStringToPath: {}", XrResultToString(instance, res)));
+        return;
+    }
+
+    // TODO: Add Valve, KHR, WMR etc.
+    {
+        XrPath oculusTouchInteractionProfilePath;
+        if (auto res = xrStringToPath(instance, "/interaction_profiles/oculus/touch_controller", &oculusTouchInteractionProfilePath); res != XR_SUCCESS) {
+            dbg(std::format("Failed to recenter VR view: {}", XrResultToString(instance, res)));
+            return;
+        }
+        std::vector<XrActionSuggestedBinding> bindings { {
+            { inputState.poseAction, posePath[Side::LEFT] },
+            { inputState.poseAction, posePath[Side::RIGHT] },
+        } };
+        XrInteractionProfileSuggestedBinding suggestedBindings { XR_TYPE_INTERACTION_PROFILE_SUGGESTED_BINDING };
+        suggestedBindings.interactionProfile = oculusTouchInteractionProfilePath;
+        suggestedBindings.suggestedBindings = bindings.data();
+        suggestedBindings.countSuggestedBindings = (uint32_t)bindings.size();
+        if (auto res = xrSuggestInteractionProfileBindings(instance, &suggestedBindings); res != XR_SUCCESS) {
+            dbg(std::format("xrSuggestInteractionProfileBindings: {}", XrResultToString(instance, res)));
+            return;
+        }
+    }
+
+    XrActionSpaceCreateInfo actionSpaceInfo { XR_TYPE_ACTION_SPACE_CREATE_INFO };
+    actionSpaceInfo.action = inputState.poseAction;
+    actionSpaceInfo.poseInActionSpace.orientation.w = 1.f;
+    actionSpaceInfo.subactionPath = inputState.handSubactionPath[Side::LEFT];
+    if (auto res = xrCreateActionSpace(session, &actionSpaceInfo, &inputState.handSpace[Side::LEFT]); res != XR_SUCCESS) {
+        dbg(std::format("xrCreateActionSpace: {}", XrResultToString(instance, res)));
+        return;
+    }
+    actionSpaceInfo.subactionPath = inputState.handSubactionPath[Side::RIGHT];
+    if (auto res = xrCreateActionSpace(session, &actionSpaceInfo, &inputState.handSpace[Side::RIGHT]); res != XR_SUCCESS) {
+        dbg(std::format("xrCreateActionSpace {}", XrResultToString(instance, res)));
+        return;
+    }
+
+    XrSessionActionSetsAttachInfo attachInfo { XR_TYPE_SESSION_ACTION_SETS_ATTACH_INFO };
+    attachInfo.countActionSets = 1;
+    attachInfo.actionSets = &inputState.actionSet;
+    if (auto res = xrAttachSessionActionSets(session, &attachInfo); res != XR_SUCCESS) {
+        dbg(std::format("xrAttachSessionActionSets: {}", XrResultToString(instance, res)));
+        return;
+    }
+    // End pose registration.
+
     XrReferenceSpaceCreateInfo view_space_create_info = {
         .type = XR_TYPE_REFERENCE_SPACE_CREATE_INFO,
         .referenceSpaceType = XR_REFERENCE_SPACE_TYPE_VIEW,
@@ -578,6 +665,9 @@ std::optional<XrViewState> OpenXR::update_views()
 
 bool OpenXR::update_vr_poses()
 {
+    //TODO: Config toggle?
+    update_poll_hand_poses();
+
     frame_state = {
         .type = XR_TYPE_FRAME_STATE,
         .next = nullptr,
@@ -616,6 +706,51 @@ bool OpenXR::update_vr_poses()
     }
 
     return true;
+}
+
+void OpenXR::update_poll_hand_poses()
+{
+    XrEventDataBuffer eventData = {
+        .type = XR_TYPE_EVENT_DATA_BUFFER,
+        .next = nullptr,
+    };
+
+    if (auto res = xrPollEvent(instance, &eventData); res == XR_SUCCESS) {
+        dbg(std::format("xrPollEvent: {}", (int) eventData.type));
+    }
+
+    //The rest in this function is probably not needed
+    inputState.handActive = { XR_FALSE, XR_FALSE };
+    const XrActiveActionSet activeActionSet { inputState.actionSet, XR_NULL_PATH };
+    XrActionsSyncInfo syncInfo { XR_TYPE_ACTIONS_SYNC_INFO };
+    syncInfo.countActiveActionSets = 1;
+    syncInfo.activeActionSets = &activeActionSet;
+    if (auto res = xrSyncActions(session, &syncInfo); res != XR_SUCCESS) {
+        dbg(std::format("xrSyncActions: {}", XrResultToString(instance, res)));
+    }
+
+
+    for (auto hand : { Side::LEFT, Side::RIGHT }) {
+        XrActionStateGetInfo getInfo { XR_TYPE_ACTION_STATE_GET_INFO };
+        getInfo.action = inputState.poseAction;
+        getInfo.subactionPath = inputState.handSubactionPath[hand];
+        XrActionStatePose poseState { XR_TYPE_ACTION_STATE_POSE };
+        if (auto res = xrGetActionStatePose(session, &getInfo, &poseState); res != XR_SUCCESS) {
+            dbg(std::format("xrGetActionStatePose: {}", XrResultToString(instance, res)));
+            continue;
+        }
+
+        if (poseState.isActive) {
+            XrSpaceLocation spaceLocation { XR_TYPE_SPACE_LOCATION };
+
+            XrResult res = xrLocateSpace(inputState.handSpace[hand], space, frame_state.predictedDisplayTime, &spaceLocation);
+            if (XR_UNQUALIFIED_SUCCESS(res) && (spaceLocation.locationFlags & XR_SPACE_LOCATION_POSITION_VALID_BIT) != 0 && (spaceLocation.locationFlags & XR_SPACE_LOCATION_ORIENTATION_VALID_BIT) != 0) {
+                // Do nothing
+            } else {
+                inputState.handActive[hand] = false;
+            }
+        }
+    }
 }
 
 bool OpenXR::get_projection_matrix()
@@ -755,6 +890,11 @@ void OpenXR::recenter_view()
 
 void OpenXR::shutdown_vr()
 {
+    //TODO: More cleanup
+    if (inputState.actionSet != XR_NULL_HANDLE) {
+        xrDestroyActionSet(inputState.actionSet);
+    }
+
     xrDestroySpace(space);
     for (const auto& v : render_contexts) {
         const auto& ctx = v.second;

--- a/src/OpenXR.cpp
+++ b/src/OpenXR.cpp
@@ -300,90 +300,8 @@ void OpenXR::init(IDirect3DDevice9* dev, IDirect3DVR9** vrdev, uint32_t companio
 
 
     // Start pose registration.
-    if (g::cfg.motion_compensation_support) {
-        XrActionSetCreateInfo actionSetInfo { XR_TYPE_ACTION_SET_CREATE_INFO };
-        strcpy_s(actionSetInfo.actionSetName, "gameplay");
-        strcpy_s(actionSetInfo.localizedActionSetName, "Gameplay");
-        actionSetInfo.priority = 0;
-        if (auto res = xrCreateActionSet(instance, &actionSetInfo, &inputState.actionSet); res != XR_SUCCESS) {
-            dbg(std::format("Failed xrCreateActionSet: {}", XrResultToString(instance, res)));
-            return;
-        }
-
-        if (auto res = xrStringToPath(instance, "/user/hand/left", &inputState.handSubactionPath[Side::LEFT]); res != XR_SUCCESS) {
-            dbg(std::format("Failed to get handsSubActionPath: {}", XrResultToString(instance, res)));
-            return;
-        }
-        if (auto res = xrStringToPath(instance, "/user/hand/right", &inputState.handSubactionPath[Side::RIGHT]); res != XR_SUCCESS) {
-            dbg(std::format("Failed to get handsSubActionPath: {}", XrResultToString(instance, res)));
-            return;
-        }
-
-        // Create an input action getting the left and right hand poses.
-        XrActionCreateInfo actionInfo { XR_TYPE_ACTION_CREATE_INFO };
-        actionInfo.actionType = XR_ACTION_TYPE_POSE_INPUT;
-        strcpy_s(actionInfo.actionName, "hand_pose");
-        strcpy_s(actionInfo.localizedActionName, "Hand Pose");
-        actionInfo.countSubactionPaths = uint32_t(inputState.handSubactionPath.size());
-        actionInfo.subactionPaths = inputState.handSubactionPath.data();
-        if (auto res = xrCreateAction(inputState.actionSet, &actionInfo, &inputState.poseAction); res != XR_SUCCESS) {
-            dbg(std::format("Failed pose xrCreateAction: {}", XrResultToString(instance, res)));
-            return;
-        }
-
-        std::array<XrPath, Side::COUNT> posePath;
-
-        if (auto res = xrStringToPath(instance, "/user/hand/left/input/grip/pose", &posePath[Side::LEFT]); res != XR_SUCCESS) {
-            dbg(std::format("xrStringToPath: {}", XrResultToString(instance, res)));
-            return;
-        }
-        if (auto res = xrStringToPath(instance, "/user/hand/right/input/grip/pose", &posePath[Side::RIGHT]); res != XR_SUCCESS) {
-            dbg(std::format("xrStringToPath: {}", XrResultToString(instance, res)));
-            return;
-        }
-
-        // TODO: Add Valve, KHR, WMR etc.
-        {
-            XrPath oculusTouchInteractionProfilePath;
-            if (auto res = xrStringToPath(instance, "/interaction_profiles/oculus/touch_controller", &oculusTouchInteractionProfilePath); res != XR_SUCCESS) {
-                dbg(std::format("Failed to recenter VR view: {}", XrResultToString(instance, res)));
-                return;
-            }
-            std::vector<XrActionSuggestedBinding> bindings { {
-                { inputState.poseAction, posePath[Side::LEFT] },
-                { inputState.poseAction, posePath[Side::RIGHT] },
-            } };
-            XrInteractionProfileSuggestedBinding suggestedBindings { XR_TYPE_INTERACTION_PROFILE_SUGGESTED_BINDING };
-            suggestedBindings.interactionProfile = oculusTouchInteractionProfilePath;
-            suggestedBindings.suggestedBindings = bindings.data();
-            suggestedBindings.countSuggestedBindings = (uint32_t)bindings.size();
-            if (auto res = xrSuggestInteractionProfileBindings(instance, &suggestedBindings); res != XR_SUCCESS) {
-                dbg(std::format("xrSuggestInteractionProfileBindings: {}", XrResultToString(instance, res)));
-                return;
-            }
-        }
-
-        XrActionSpaceCreateInfo actionSpaceInfo { XR_TYPE_ACTION_SPACE_CREATE_INFO };
-        actionSpaceInfo.action = inputState.poseAction;
-        actionSpaceInfo.poseInActionSpace.orientation.w = 1.f;
-        actionSpaceInfo.subactionPath = inputState.handSubactionPath[Side::LEFT];
-        if (auto res = xrCreateActionSpace(session, &actionSpaceInfo, &inputState.handSpace[Side::LEFT]); res != XR_SUCCESS) {
-            dbg(std::format("xrCreateActionSpace: {}", XrResultToString(instance, res)));
-            return;
-        }
-        actionSpaceInfo.subactionPath = inputState.handSubactionPath[Side::RIGHT];
-        if (auto res = xrCreateActionSpace(session, &actionSpaceInfo, &inputState.handSpace[Side::RIGHT]); res != XR_SUCCESS) {
-            dbg(std::format("xrCreateActionSpace {}", XrResultToString(instance, res)));
-            return;
-        }
-
-        XrSessionActionSetsAttachInfo attachInfo { XR_TYPE_SESSION_ACTION_SETS_ATTACH_INFO };
-        attachInfo.countActionSets = 1;
-        attachInfo.actionSets = &inputState.actionSet;
-        if (auto res = xrAttachSessionActionSets(session, &attachInfo); res != XR_SUCCESS) {
-            dbg(std::format("xrAttachSessionActionSets: {}", XrResultToString(instance, res)));
-            return;
-        }
+    if (g::cfg.openxr_motion_compensation) {
+        init_motion_compensation_support();
     }
 
     XrReferenceSpaceCreateInfo view_space_create_info = {
@@ -467,6 +385,174 @@ const char* OpenXR::get_device_extensions()
         }
     }
     return device_extensions.data();
+}
+
+void OpenXR::init_motion_compensation_support()
+{
+    XrActionSetCreateInfo actionSetInfo { XR_TYPE_ACTION_SET_CREATE_INFO };
+    strcpy_s(actionSetInfo.actionSetName, "gameplay");
+    strcpy_s(actionSetInfo.localizedActionSetName, "Gameplay");
+    actionSetInfo.priority = 0;
+    if (auto res = xrCreateActionSet(instance, &actionSetInfo, &inputState.actionSet); res != XR_SUCCESS) {
+        dbg(std::format("Failed xrCreateActionSet: {}", XrResultToString(instance, res)));
+        return;
+    }
+
+    if (auto res = xrStringToPath(instance, "/user/hand/left", &inputState.handSubactionPath[Side::LEFT]); res != XR_SUCCESS) {
+        dbg(std::format("Failed to get handsSubActionPath: {}", XrResultToString(instance, res)));
+        return;
+    }
+    if (auto res = xrStringToPath(instance, "/user/hand/right", &inputState.handSubactionPath[Side::RIGHT]); res != XR_SUCCESS) {
+        dbg(std::format("Failed to get handsSubActionPath: {}", XrResultToString(instance, res)));
+        return;
+    }
+
+    // Create an input action getting the left and right hand poses.
+    XrActionCreateInfo actionInfo { XR_TYPE_ACTION_CREATE_INFO };
+    actionInfo.actionType = XR_ACTION_TYPE_POSE_INPUT;
+    strcpy_s(actionInfo.actionName, "hand_pose");
+    strcpy_s(actionInfo.localizedActionName, "Hand Pose");
+    actionInfo.countSubactionPaths = uint32_t(inputState.handSubactionPath.size());
+    actionInfo.subactionPaths = inputState.handSubactionPath.data();
+    if (auto res = xrCreateAction(inputState.actionSet, &actionInfo, &inputState.poseAction); res != XR_SUCCESS) {
+        dbg(std::format("Failed pose xrCreateAction: {}", XrResultToString(instance, res)));
+        return;
+    }
+
+
+    if (!init_motion_compensation_suggest_bindings()) { 
+        return;
+    }
+
+    XrActionSpaceCreateInfo actionSpaceInfo { XR_TYPE_ACTION_SPACE_CREATE_INFO };
+    actionSpaceInfo.action = inputState.poseAction;
+    actionSpaceInfo.poseInActionSpace.orientation.w = 1.f;
+    actionSpaceInfo.subactionPath = inputState.handSubactionPath[Side::LEFT];
+    if (auto res = xrCreateActionSpace(session, &actionSpaceInfo, &inputState.handSpace[Side::LEFT]); res != XR_SUCCESS) {
+        dbg(std::format("xrCreateActionSpace: {}", XrResultToString(instance, res)));
+        return;
+    }
+    actionSpaceInfo.subactionPath = inputState.handSubactionPath[Side::RIGHT];
+    if (auto res = xrCreateActionSpace(session, &actionSpaceInfo, &inputState.handSpace[Side::RIGHT]); res != XR_SUCCESS) {
+        dbg(std::format("xrCreateActionSpace {}", XrResultToString(instance, res)));
+        return;
+    }
+
+    XrSessionActionSetsAttachInfo attachInfo { XR_TYPE_SESSION_ACTION_SETS_ATTACH_INFO };
+    attachInfo.countActionSets = 1;
+    attachInfo.actionSets = &inputState.actionSet;
+    if (auto res = xrAttachSessionActionSets(session, &attachInfo); res != XR_SUCCESS) {
+        dbg(std::format("xrAttachSessionActionSets: {}", XrResultToString(instance, res)));
+        return;
+    }
+}
+
+bool OpenXR::init_motion_compensation_suggest_bindings()
+{
+    std::array<XrPath, Side::COUNT> posePath;
+
+    if (auto res = xrStringToPath(instance, "/user/hand/left/input/grip/pose", &posePath[Side::LEFT]); res != XR_SUCCESS) {
+        dbg(std::format("xrStringToPath: {}", XrResultToString(instance, res)));
+        return false;
+    }
+    if (auto res = xrStringToPath(instance, "/user/hand/right/input/grip/pose", &posePath[Side::RIGHT]); res != XR_SUCCESS) {
+        dbg(std::format("xrStringToPath: {}", XrResultToString(instance, res)));
+        return false;
+    }
+
+    XrPath khrSimpleInteractionProfilePath;
+    if (auto res = xrStringToPath(instance, "/interaction_profiles/khr/simple_controller", &khrSimpleInteractionProfilePath); res != XR_SUCCESS) {
+        dbg(std::format("xrStringToPath failed: {}", XrResultToString(instance, res)));
+        return false;
+    }
+
+    {
+        std::vector<XrActionSuggestedBinding> bindings { { { inputState.poseAction, posePath[Side::LEFT] },
+            { inputState.poseAction, posePath[Side::RIGHT] } } };
+        XrInteractionProfileSuggestedBinding suggestedBindings { XR_TYPE_INTERACTION_PROFILE_SUGGESTED_BINDING };
+        suggestedBindings.interactionProfile = khrSimpleInteractionProfilePath;
+        suggestedBindings.suggestedBindings = bindings.data();
+        suggestedBindings.countSuggestedBindings = (uint32_t)bindings.size();
+        if (auto res = xrSuggestInteractionProfileBindings(instance, &suggestedBindings)) {
+            dbg(std::format("xrSuggestInteractionProfileBindings: {}", XrResultToString(instance, res)));
+            return false;
+        }
+    }
+    {
+        XrPath oculusTouchInteractionProfilePath;
+        if (auto res = xrStringToPath(instance, "/interaction_profiles/oculus/touch_controller", &oculusTouchInteractionProfilePath); res != XR_SUCCESS) {
+            dbg(std::format("xrStringToPath failed: {}", XrResultToString(instance, res)));
+            return false;
+        }
+
+        std::vector<XrActionSuggestedBinding> bindings { {
+            { inputState.poseAction, posePath[Side::LEFT] },
+            { inputState.poseAction, posePath[Side::RIGHT] },
+        } };
+        XrInteractionProfileSuggestedBinding suggestedBindings { XR_TYPE_INTERACTION_PROFILE_SUGGESTED_BINDING };
+        suggestedBindings.interactionProfile = oculusTouchInteractionProfilePath;
+        suggestedBindings.suggestedBindings = bindings.data();
+        suggestedBindings.countSuggestedBindings = (uint32_t)bindings.size();
+        if (auto res = xrSuggestInteractionProfileBindings(instance, &suggestedBindings); res != XR_SUCCESS) {
+            dbg(std::format("xrSuggestInteractionProfileBindings: {}", XrResultToString(instance, res)));
+            return false;
+        }
+    }
+    {
+        XrPath viveControllerInteractionProfilePath;
+        if (auto res = xrStringToPath(instance, "/interaction_profiles/htc/vive_controller", &viveControllerInteractionProfilePath); res != XR_SUCCESS) {
+            dbg(std::format("xrStringToPath failed: {}", XrResultToString(instance, res)));
+            return false;
+        }
+
+        std::vector<XrActionSuggestedBinding> bindings { { { inputState.poseAction, posePath[Side::LEFT] },
+            { inputState.poseAction, posePath[Side::RIGHT] } } };
+        XrInteractionProfileSuggestedBinding suggestedBindings { XR_TYPE_INTERACTION_PROFILE_SUGGESTED_BINDING };
+        suggestedBindings.interactionProfile = viveControllerInteractionProfilePath;
+        suggestedBindings.suggestedBindings = bindings.data();
+        suggestedBindings.countSuggestedBindings = (uint32_t)bindings.size();
+        if (auto res = xrSuggestInteractionProfileBindings(instance, &suggestedBindings)) {
+            dbg(std::format("xrSuggestInteractionProfileBindings: {}", XrResultToString(instance, res)));
+            return false;
+        }
+    }
+    {
+        XrPath indexControllerInteractionProfilePath;
+        if (auto res = xrStringToPath(instance, "/interaction_profiles/valve/index_controller", &indexControllerInteractionProfilePath); res != XR_SUCCESS) {
+            dbg(std::format("xrStringToPath failed: {}", XrResultToString(instance, res)));
+            return false;
+        }
+
+        std::vector<XrActionSuggestedBinding> bindings { { { inputState.poseAction, posePath[Side::LEFT] },
+            { inputState.poseAction, posePath[Side::RIGHT] } } };
+        XrInteractionProfileSuggestedBinding suggestedBindings { XR_TYPE_INTERACTION_PROFILE_SUGGESTED_BINDING };
+        suggestedBindings.interactionProfile = indexControllerInteractionProfilePath;
+        suggestedBindings.suggestedBindings = bindings.data();
+        suggestedBindings.countSuggestedBindings = (uint32_t)bindings.size();
+        if (auto res = xrSuggestInteractionProfileBindings(instance, &suggestedBindings)) {
+            dbg(std::format("xrSuggestInteractionProfileBindings: {}", XrResultToString(instance, res)));
+            return false;
+        }
+    }
+    {
+        XrPath microsoftMixedRealityInteractionProfilePath;
+        if (auto res = xrStringToPath(instance, "/interaction_profiles/microsoft/motion_controller", &microsoftMixedRealityInteractionProfilePath);
+            res != XR_SUCCESS) {
+            dbg(std::format("xrStringToPath failed: {}", XrResultToString(instance, res)));
+            return false;
+        }
+        std::vector<XrActionSuggestedBinding> bindings { { { inputState.poseAction, posePath[Side::LEFT] },
+            { inputState.poseAction, posePath[Side::RIGHT] } } };
+        XrInteractionProfileSuggestedBinding suggestedBindings { XR_TYPE_INTERACTION_PROFILE_SUGGESTED_BINDING };
+        suggestedBindings.interactionProfile = microsoftMixedRealityInteractionProfilePath;
+        suggestedBindings.suggestedBindings = bindings.data();
+        suggestedBindings.countSuggestedBindings = (uint32_t)bindings.size();
+        if (auto res = xrSuggestInteractionProfileBindings(instance, &suggestedBindings)) {
+            dbg(std::format("xrSuggestInteractionProfileBindings: {}", XrResultToString(instance, res)));
+            return false;
+        }
+    }
+    return true;
 }
 
 const char* OpenXR::get_instance_extensions()
@@ -666,7 +752,7 @@ std::optional<XrViewState> OpenXR::update_views()
 
 bool OpenXR::update_vr_poses()
 {
-    if (g::cfg.motion_compensation_support) {
+    if (g::cfg.openxr_motion_compensation) {
         update_poll_hand_poses();
     }
 
@@ -893,7 +979,7 @@ void OpenXR::recenter_view()
 
 void OpenXR::shutdown_vr()
 {
-    if (g::cfg.motion_compensation_support) {
+    if (g::cfg.openxr_motion_compensation) {
         // TODO: More cleanup
         if (inputState.actionSet != XR_NULL_HANDLE) {
             xrDestroyActionSet(inputState.actionSet);

--- a/src/OpenXR.cpp
+++ b/src/OpenXR.cpp
@@ -803,11 +803,10 @@ void OpenXR::update_poll_hand_poses()
         .next = nullptr,
     };
 
+    // This should perhaps be moved to the main loop to be able to detect changes (disconnects) where you need to recreate xrSession and re-init.
     if (auto res = xrPollEvent(instance, &eventData); res == XR_SUCCESS) {
         dbg(std::format("xrPollEvent: {}", (int) eventData.type));
     }
-
-    //TODO: The rest in this function is probably not needed, needs testing.
 
     inputState.handActive = { XR_FALSE, XR_FALSE };
     const XrActiveActionSet activeActionSet { inputState.actionSet, XR_NULL_PATH };
@@ -817,7 +816,6 @@ void OpenXR::update_poll_hand_poses()
     if (auto res = xrSyncActions(session, &syncInfo); res != XR_SUCCESS) {
         dbg(std::format("xrSyncActions: {}", XrResultToString(instance, res)));
     }
-
 
     for (auto hand : { Side::LEFT, Side::RIGHT }) {
         XrActionStateGetInfo getInfo { XR_TYPE_ACTION_STATE_GET_INFO };

--- a/src/OpenXR.hpp
+++ b/src/OpenXR.hpp
@@ -16,6 +16,20 @@ struct OpenXRRenderContext {
     std::array<XrCompositionLayerProjectionView, 2> projection_views;
 };
 
+namespace Side {
+    const int LEFT = 0;
+    const int RIGHT = 1;
+    const int COUNT = 2;
+}
+
+struct InputState {
+    XrActionSet actionSet { XR_NULL_HANDLE };
+    XrAction poseAction { XR_NULL_HANDLE };
+    std::array<XrPath, Side::COUNT> handSubactionPath;
+    std::array<XrSpace, Side::COUNT> handSpace;
+    std::array<XrBool32, Side::COUNT> handActive;
+};
+
 class OpenXR : public VRInterface {
 private:
     XrSession session;
@@ -26,6 +40,7 @@ private:
     XrFrameState frame_state;
     int64_t swapchain_format;
     XrPosef view_pose;
+    InputState inputState;
     bool has_projection;
     bool reset_view_requested;
 
@@ -63,6 +78,7 @@ public:
 
     void shutdown_vr() override;
     bool update_vr_poses() override;
+    void update_poll_hand_poses();
     void prepare_frames_for_hmd(IDirect3DDevice9* dev) override;
     void submit_frames_to_hmd(IDirect3DDevice9* dev) override;
     void reset_view() override;

--- a/src/OpenXR.hpp
+++ b/src/OpenXR.hpp
@@ -71,6 +71,8 @@ public:
     OpenXR& operator=(const OpenXR&&) = delete;
 
     void init(IDirect3DDevice9* dev, IDirect3DVR9** vrdev, uint32_t companionWindowWidth, uint32_t companionWindowHeight);
+    void init_motion_compensation_support();
+    bool init_motion_compensation_suggest_bindings();
     virtual ~OpenXR()
     {
         shutdown_vr();

--- a/src/OpenXR.hpp
+++ b/src/OpenXR.hpp
@@ -40,7 +40,7 @@ private:
     XrFrameState frame_state;
     int64_t swapchain_format;
     XrPosef view_pose;
-    InputState inputState;
+    InputState inputState; // For sending poses to OpenXR-MotionCompensation https://github.com/BuzzteeBear/OpenXR-MotionCompensation
     bool has_projection;
     bool reset_view_requested;
 


### PR DESCRIPTION
Added support for controllers sending poses to be used as trackers when using motion compensation in motion simulators. 
Disabled by default, can be toggled in OpenXR settings menu in RBR and saved in toml-file.

* VR controllers sends poses to OpenXR.
* Supports Oculus controllers, Vive controllers, Index controllers, MS mixed reality controllers.

